### PR TITLE
Fix PlotValues.PCA.Gene.10x when log2.transform is FALSE

### DIFF
--- a/R/Script_DROPLET_07_ADHOC_PLOT_PCA_3_PlotValues_Gene.R
+++ b/R/Script_DROPLET_07_ADHOC_PLOT_PCA_3_PlotValues_Gene.R
@@ -144,6 +144,10 @@ PlotValues.PCA.Gene.10x <- function(MarvelObject, cell.ids=NULL, gene_short_name
     if(log2.transform==TRUE) {
         
         z <- log2(data$expr.gene.norm + 1)
+
+    } else {
+
+        z <- data$expr.gene.norm
     
     }
     
@@ -159,7 +163,16 @@ PlotValues.PCA.Gene.10x <- function(MarvelObject, cell.ids=NULL, gene_short_name
     
     }
     
-    legendtitle <- "log2(expr)"
+    if(log2.transform==TRUE) {
+
+      legendtitle <- "log2(expr)"
+
+    } else {
+
+      legendtitle <- "expr"
+
+    }
+
     
     # Plot
     plot <- ggplot() +


### PR DESCRIPTION
When log2.transform is FALSE the z and legendtitle variables in PlotValues.PCA.Gene.10x are not initialized which results in an error while creating the plot.  The error is corrected by providing values for these variables when log2.transform is FALSE.